### PR TITLE
Fix error in x axes of calibrating a determination

### DIFF
--- a/R/CalibrateSingleDetermination.R
+++ b/R/CalibrateSingleDetermination.R
@@ -31,7 +31,7 @@ CalibrateSingleDetermination <- function(
 
   return(
     data.frame(
-      calendar_age=calibration_curve$c14_age, probability=probabilities))
+      calendar_age=calibration_curve$calendar_age, probability=probabilities))
 }
 
 


### PR DESCRIPTION
Calibrate single determination should have calendar age as the X axis not the intcal20 c14 age