### PR TITLE
Fixing warning in find_predictive_density.cpp 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # carbondate (development version)
 
+* Fixed warning in cpp using return std::move(retdata) where retdata is just named value
+
 # carbondate 1.1.0
 
 * Added `plot_lwd` argument to alter width of lines when plotting PP and DPMM. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # carbondate (development version)
 
-* Fixed warning in cpp using return std::move(retdata) where retdata is just named value
+* Fixed warning in find_predictive_density.cpp by using return std::move(retdata) where retdata was just named local variable
 
 # carbondate 1.1.0
 

--- a/src/find_predictive_density.cpp
+++ b/src/find_predictive_density.cpp
@@ -165,7 +165,7 @@ double PolyaUrnDensityForCalendarAge(
     "density_ci_upper"_nm = ci_upper,
   });
 
-  return retdata;
+  return std::move(retdata);
 }
 
 // Finds mean predictive density and confidence intervals, sampling over a given number of points
@@ -223,7 +223,7 @@ double PolyaUrnDensityForCalendarAge(
       "density_ci_upper"_nm = ci_upper,
   });
 
-  return retdata;
+  return std::move(retdata);
 }
 
 // Finds predictive density at a single data point


### PR DESCRIPTION
Called std::move(retdata) to avoid unnecessary copying of local variable 